### PR TITLE
Escape currency symbols in string templates

### DIFF
--- a/app/src/main/java/com/example/swiftbus/BookingSummaryActivity.kt
+++ b/app/src/main/java/com/example/swiftbus/BookingSummaryActivity.kt
@@ -28,9 +28,9 @@ class BookingSummaryActivity : AppCompatActivity() {
 
         busNameTextView.text = busName
         selectedSeatsTextView.text = "Seats: $selectedSeats"
-        baseFareTextView.text = "$$totalAmount"
-        taxesTextView.text = "$$taxes"
-        totalFareTextView.text = "$$finalAmount"
+        baseFareTextView.text = "\$${totalAmount}"
+        taxesTextView.text = "\$${taxes}"
+        totalFareTextView.text = "\$${finalAmount}"
 
         proceedButton.setOnClickListener {
             val intent = Intent(this, PaymentActivity::class.java)

--- a/app/src/main/java/com/example/swiftbus/BusDetailsActivity.kt
+++ b/app/src/main/java/com/example/swiftbus/BusDetailsActivity.kt
@@ -13,7 +13,7 @@ class BusDetailsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_bus_details)
 
         val busName = intent.getStringExtra("busName") ?: "Unknown Bus"
-        val busPrice = intent.getStringExtra("busPrice") ?: "$0"
+        val busPrice = intent.getStringExtra("busPrice") ?: "\$0"
 
         val busNameTextView = findViewById<TextView>(R.id.tvBusName)
         val busPriceTextView = findViewById<TextView>(R.id.tvBusPrice)

--- a/app/src/main/java/com/example/swiftbus/PaymentActivity.kt
+++ b/app/src/main/java/com/example/swiftbus/PaymentActivity.kt
@@ -21,7 +21,7 @@ class PaymentActivity : AppCompatActivity() {
         val totalAmountTextView = findViewById<TextView>(R.id.tvTotalAmount)
         val payNowButton = findViewById<Button>(R.id.btnPayNow)
 
-        totalAmountTextView.text = "$$totalAmount"
+        totalAmountTextView.text = "\$${totalAmount}"
 
         payNowButton.setOnClickListener {
             // Simulate payment processing

--- a/app/src/main/java/com/example/swiftbus/SearchResultsActivity.kt
+++ b/app/src/main/java/com/example/swiftbus/SearchResultsActivity.kt
@@ -23,21 +23,21 @@ class SearchResultsActivity : AppCompatActivity() {
         bus1Card.setOnClickListener {
             val intent = Intent(this, BusDetailsActivity::class.java)
             intent.putExtra("busName", "Swift Express")
-            intent.putExtra("busPrice", "$45")
+            intent.putExtra("busPrice", "\$45")
             startActivity(intent)
         }
 
         bus2Card.setOnClickListener {
             val intent = Intent(this, BusDetailsActivity::class.java)
             intent.putExtra("busName", "Comfort Travels")
-            intent.putExtra("busPrice", "$38")
+            intent.putExtra("busPrice", "\$38")
             startActivity(intent)
         }
 
         bus3Card.setOnClickListener {
             val intent = Intent(this, BusDetailsActivity::class.java)
             intent.putExtra("busName", "Royal Rides")
-            intent.putExtra("busPrice", "$52")
+            intent.putExtra("busPrice", "\$52")
             startActivity(intent)
         }
     }

--- a/app/src/main/java/com/example/swiftbus/SeatSelectionActivity.kt
+++ b/app/src/main/java/com/example/swiftbus/SeatSelectionActivity.kt
@@ -80,6 +80,6 @@ class SeatSelectionActivity : AppCompatActivity() {
 
     private fun updateSelection(seatPrice: Int) {
         selectedCountTextView.text = "${selectedSeats.size} seat(s) selected"
-        totalAmountTextView.text = "$${selectedSeats.size * seatPrice}"
+        totalAmountTextView.text = "\$${selectedSeats.size * seatPrice}"
     }
 }

--- a/app/src/main/java/com/example/swiftbus/TicketConfirmationActivity.kt
+++ b/app/src/main/java/com/example/swiftbus/TicketConfirmationActivity.kt
@@ -27,7 +27,7 @@ class TicketConfirmationActivity : AppCompatActivity() {
         ticketNumberTextView.text = ticketNumber
         busNameTextView.text = busName
         seatsTextView.text = selectedSeats
-        amountTextView.text = "$$totalAmount"
+        amountTextView.text = "\$${totalAmount}"
 
         viewBookingsButton.setOnClickListener {
             startActivity(Intent(this, MyBookingsActivity::class.java))


### PR DESCRIPTION
## Summary
- Escape string template dollar signs for hardcoded prices and amounts across activities
- Ensure currency amounts like base fare, taxes, and totals display correctly

## Testing
- ⚠️ `./gradlew test` (failed: Unable to tunnel through proxy; HTTP/1.1 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68accfb1c61c83219e4aa7fb3215cf2e